### PR TITLE
Code cleanup and refactor

### DIFF
--- a/CaptureZoneInfo.lua
+++ b/CaptureZoneInfo.lua
@@ -2,82 +2,82 @@ TorteMe = TorteMe or {}
 
 function TorteMe:CaptureZoneInfo(loadType)
 
-	if loadType == "login"  or loadType == "reload" then
-		TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
-		TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
-		TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
-		TorteMe.sv.Zone.oldZoneId = 0
-		TorteMe.sv.Zone.oldParentZoneId = 0
-		TorteMe.sv.Zone.oldZoneName = "Unknown"
-		if loadType == "login" then
-			if TorteMe.sv.Zone.parentZoneId == 181 then
-				TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
-				TorteMe:Notify("Welcome to Cyrodiil!")
-				TorteMe:Log("Cyrodiil Login Detected.", true, 5)
-				if TorteMe.sv.Zone.zoneId == 181 then
-					TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-				else
-					TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-				end
-			else
-				TorteMe:Log("Non-Cyrodiil Login Detected.", true, 5)
-				TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-			end
-		else
-			if TorteMe.sv.Zone.parentZoneId == 181 then
-				TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
-				TorteMe:Notify("Welcome to Cyrodiil!")
-				TorteMe:Log("ReloadUI IN Cyrodiil.", true, 25)
-				if TorteMe.sv.Zone.zoneId == 181 then
-					TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-				else
-					TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-				end
-			else 
-				TorteMe:Log("Non-Cyrodiil ReloadUI Detected.", true, 5)
-				TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-			end
-		end
-	else
-		TorteMe.sv.Zone.oldZoneId = TorteMe.sv.Zone.zoneId
-		TorteMe.sv.Zone.oldParentZoneId = TorteMe.sv.Zone.parentZoneId
-		TorteMe.sv.Zone.oldZoneName = TorteMe.sv.Zone.zoneName
-		TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
-		TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
-		TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
-		if TorteMe.sv.Zone.parentZoneId == 181 and TorteMe.sv.Zone.oldParentZoneId ~= 181 then
-			TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
-			TorteMe:Notify("Welcome to Cyrodiil!")			
-			TorteMe:Log("Zoned INTO Cyrodiil.", true, 5)
-			TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-		elseif TorteMe.sv.Zone.parentZoneId == 181 and TorteMe.sv.Zone.oldParentZoneId == 181 then
-			TorteMe:Log("Zoned WITHIN Cyrodiil.", true, 5)
-			if TorteMe.sv.Zone.oldZoneId == 181 and TorteMe.sv.Zone.zoneId ~= 181 then
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-			elseif TorteMe.sv.Zone.oldZoneId ~= 181 and TorteMe.sv.Zone.zoneId == 181 then
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-			else
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-			end
+  if loadType == "login"  or loadType == "reload" then
+    TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
+    TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
+    TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
+    TorteMe.sv.Zone.oldZoneId = 0
+    TorteMe.sv.Zone.oldParentZoneId = 0
+    TorteMe.sv.Zone.oldZoneName = "Unknown"
+    if loadType == "login" then
+      if TorteMe.sv.Zone.parentZoneId == 181 then
+        TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
+        TorteMe:Notify("Welcome to Cyrodiil!")
+        TorteMe:Log("Cyrodiil Login Detected.", true, 5)
+        if TorteMe.sv.Zone.zoneId == 181 then
+          TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 25)
+        else
+          TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
+        end
+      else
+        TorteMe:Log("Non-Cyrodiil Login Detected.", true, 5)
+        TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 20)
+      end
+    else
+      if TorteMe.sv.Zone.parentZoneId == 181 then
+        TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
+        TorteMe:Notify("Welcome to Cyrodiil!")
+        TorteMe:Log("ReloadUI IN Cyrodiil.", true, 25)
+        if TorteMe.sv.Zone.zoneId == 181 then
+          TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 25)
+        else
+          TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
+        end
+      else
+        TorteMe:Log("Non-Cyrodiil ReloadUI Detected.", true, 5)
+        TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 20)
+      end
+    end
+  else
+    TorteMe.sv.Zone.oldZoneId = TorteMe.sv.Zone.zoneId
+    TorteMe.sv.Zone.oldParentZoneId = TorteMe.sv.Zone.parentZoneId
+    TorteMe.sv.Zone.oldZoneName = TorteMe.sv.Zone.zoneName
+    TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
+    TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
+    TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
+    if TorteMe.sv.Zone.parentZoneId == 181 and TorteMe.sv.Zone.oldParentZoneId ~= 181 then
+      TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
+      TorteMe:Notify("Welcome to Cyrodiil!")
+      TorteMe:Log("Zoned INTO Cyrodiil.", true, 5)
+      TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
+    elseif TorteMe.sv.Zone.parentZoneId == 181 and TorteMe.sv.Zone.oldParentZoneId == 181 then
+      TorteMe:Log("Zoned WITHIN Cyrodiil.", true, 5)
+      if TorteMe.sv.Zone.oldZoneId == 181 and TorteMe.sv.Zone.zoneId ~= 181 then
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
+      elseif TorteMe.sv.Zone.oldZoneId ~= 181 and TorteMe.sv.Zone.zoneId == 181 then
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 25)
+      else
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
+      end
 
-		elseif TorteMe.sv.Zone.parentZoneId ~= 181 and TorteMe.sv.Zone.oldParentZoneId == 181 then
-			TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
-			TorteMe:Notify("Left Cyrodiil!")			
-			TorteMe:Log("Zoned OUT of Cyrodiil.", true, 5)
-			if TorteMe.sv.Zone.oldZoneId == 181 then
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-			elseif TorteMe.sv.Zone.oldZoneId ~=181 then
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. "(Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-			end
+    elseif TorteMe.sv.Zone.parentZoneId ~= 181 and TorteMe.sv.Zone.oldParentZoneId == 181 then
+      TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
+      TorteMe:Notify("Left Cyrodiil!")
+      TorteMe:Log("Zoned OUT of Cyrodiil.", true, 5)
+      if TorteMe.sv.Zone.oldZoneId == 181 then
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
+      elseif TorteMe.sv.Zone.oldZoneId ~=181 then
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. "(Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
+      end
 
-		else
-			TorteMe:Log("Non-Cyrodiil Zone Detected.", true, 5)
-			if TorteMe.sv.Zone.oldParentZoneId == 181 and TorteMe.sv.Zone.oldZoneId ~= 181 then
-				TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-			else 
-				TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-			end
-		end
-	end
+    else
+      TorteMe:Log("Non-Cyrodiil Zone Detected.", true, 5)
+      if TorteMe.sv.Zone.oldParentZoneId == 181 and TorteMe.sv.Zone.oldZoneId ~= 181 then
+        TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
+      else
+        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
+      end
+    end
+  end
 end

--- a/CaptureZoneInfo.lua
+++ b/CaptureZoneInfo.lua
@@ -1,83 +1,58 @@
 TorteMe = TorteMe or {}
 
+-- Valid loadType = login, reload, zone
 function TorteMe:CaptureZoneInfo(loadType)
 
-  if loadType == "login"  or loadType == "reload" then
-    TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
-    TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
-    TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
+  local loadTypeStr = ""
+  local zoneDirectionStrInCyro = ""
+  local zoneDirectionStrExitCyro = ""
+  local zoneDirectionStrEnterCyro = ""
+  local zoneDirectionStr = ""
+
+  if loadType == "login" or loadType == "reload" then
     TorteMe.sv.Zone.oldZoneId = 0
     TorteMe.sv.Zone.oldParentZoneId = 0
     TorteMe.sv.Zone.oldZoneName = "Unknown"
+    TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
+    TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
+    TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
     if loadType == "login" then
-      if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
-        TorteMe:Notify("Welcome to Cyrodiil!")
-        TorteMe:Log("Cyrodiil Login Detected.", true, 5)
-        if TorteMe.sv.Zone.zoneId == TorteMe.const.ZONEID_CYRODIIL then
-          TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-        else
-          TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-        end
-      else
-        TorteMe:Log("Non-Cyrodiil Login Detected.", true, 5)
-        TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      end
-    else
-      if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
-        TorteMe:Notify("Welcome to Cyrodiil!")
-        TorteMe:Log("ReloadUI IN Cyrodiil.", true, 25)
-        if TorteMe.sv.Zone.zoneId == TorteMe.const.ZONEID_CYRODIIL then
-          TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-        else
-          TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-        end
-      else
-        TorteMe:Log("Non-Cyrodiil ReloadUI Detected.", true, 5)
-        TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      end
+      loadTypeStr = "Login"
+    elseif loadType == "reload" then
+      loadTypeStr = "ReloadUI"
     end
-  else
+  elseif loadType == "zone" then
     TorteMe.sv.Zone.oldZoneId = TorteMe.sv.Zone.zoneId
     TorteMe.sv.Zone.oldParentZoneId = TorteMe.sv.Zone.parentZoneId
     TorteMe.sv.Zone.oldZoneName = TorteMe.sv.Zone.zoneName
     TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
     TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
     TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
-    if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId ~= TorteMe.const.ZONEID_CYRODIIL then
-      TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
-      TorteMe:Notify("Welcome to Cyrodiil!")
-      TorteMe:Log("Zoned INTO Cyrodiil.", true, 5)
-      TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-    elseif TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
-      TorteMe:Log("Zoned WITHIN Cyrodiil.", true, 5)
-      if TorteMe.sv.Zone.oldZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.zoneId ~= TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-      elseif TorteMe.sv.Zone.oldZoneId ~= TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.zoneId == TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-      else
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-      end
+    loadTypeStr = "Zone Change"
+  end
 
-    elseif TorteMe.sv.Zone.parentZoneId ~= TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
-      TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
-      TorteMe:Notify("Left Cyrodiil!")
-      TorteMe:Log("Zoned OUT of Cyrodiil.", true, 5)
-      if TorteMe.sv.Zone.oldZoneId == TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      elseif TorteMe.sv.Zone.oldZoneId ~=TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. "(Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      end
+  zoneDirectionStrInCyro = TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName
+  zoneDirectionStrExitCyro = TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName
+  zoneDirectionStrEnterCyro = TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName.." (Cyrodiil) "
 
-    else
-      TorteMe:Log("Non-Cyrodiil Zone Detected.", true, 5)
-      if TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldZoneId ~= TorteMe.const.ZONEID_CYRODIIL then
-        TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      else
-        TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      end
-    end
+  TorteMe:Log("oldParentZoneId "..TorteMe.sv.Zone.oldParentZoneId.." newParentZoneId "..TorteMe.sv.Zone.parentZoneId, true, 25)
+
+  if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId ~= TorteMe.const.ZONEID_CYRODIIL then
+    TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
+    TorteMe:Notify("Welcome to Cyrodiil!")
+    zoneDirectionStr = zoneDirectionStrEnterCyro
+  elseif TorteMe.sv.Zone.parentZoneId ~= TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
+    TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
+    TorteMe:Notify("Left Cyrodiil!")
+    zoneDirectionStr = zoneDirectionStrExitCyro
+  elseif TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
+    TorteMe:Log("Movement in Cyrodiil - " .. TorteMe.displayName .. " enabled.")
+    TorteMe:Notify("Scene Change in Cyrodiil")
+    zoneDirectionStr = zoneDirectionStrInCyro
+  end
+
+  if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL or TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
+    TorteMe:Log(loadTypeStr.." Detected.", true, 25)
+    TorteMe:Log(zoneDirectionStr, true, 20)
   end
 end

--- a/CaptureZoneInfo.lua
+++ b/CaptureZoneInfo.lua
@@ -10,11 +10,11 @@ function TorteMe:CaptureZoneInfo(loadType)
     TorteMe.sv.Zone.oldParentZoneId = 0
     TorteMe.sv.Zone.oldZoneName = "Unknown"
     if loadType == "login" then
-      if TorteMe.sv.Zone.parentZoneId == 181 then
+      if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
         TorteMe:Notify("Welcome to Cyrodiil!")
         TorteMe:Log("Cyrodiil Login Detected.", true, 5)
-        if TorteMe.sv.Zone.zoneId == 181 then
+        if TorteMe.sv.Zone.zoneId == TorteMe.const.ZONEID_CYRODIIL then
           TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 25)
         else
           TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
@@ -24,11 +24,11 @@ function TorteMe:CaptureZoneInfo(loadType)
         TorteMe:Log("Login -> " .. TorteMe.sv.Zone.zoneName, true, 20)
       end
     else
-      if TorteMe.sv.Zone.parentZoneId == 181 then
+      if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
         TorteMe:Notify("Welcome to Cyrodiil!")
         TorteMe:Log("ReloadUI IN Cyrodiil.", true, 25)
-        if TorteMe.sv.Zone.zoneId == 181 then
+        if TorteMe.sv.Zone.zoneId == TorteMe.const.ZONEID_CYRODIIL then
           TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName, true, 25)
         else
           TorteMe:Log("ReloadUI -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
@@ -45,34 +45,34 @@ function TorteMe:CaptureZoneInfo(loadType)
     TorteMe.sv.Zone.zoneId = GetZoneId(GetUnitZoneIndex("player"))
     TorteMe.sv.Zone.parentZoneId = GetParentZoneId(TorteMe.sv.Zone.zoneId)
     TorteMe.sv.Zone.zoneName = GetZoneNameById(TorteMe.sv.Zone.zoneId)
-    if TorteMe.sv.Zone.parentZoneId == 181 and TorteMe.sv.Zone.oldParentZoneId ~= 181 then
+    if TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId ~= TorteMe.const.ZONEID_CYRODIIL then
       TorteMe:Log("Welcome To Cyrodiil! - " .. TorteMe.displayName .. " enabled.")
       TorteMe:Notify("Welcome to Cyrodiil!")
       TorteMe:Log("Zoned INTO Cyrodiil.", true, 5)
       TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
-    elseif TorteMe.sv.Zone.parentZoneId == 181 and TorteMe.sv.Zone.oldParentZoneId == 181 then
+    elseif TorteMe.sv.Zone.parentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
       TorteMe:Log("Zoned WITHIN Cyrodiil.", true, 5)
-      if TorteMe.sv.Zone.oldZoneId == 181 and TorteMe.sv.Zone.zoneId ~= 181 then
+      if TorteMe.sv.Zone.oldZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.zoneId ~= TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName .. " (Cyrodiil)", true, 25)
-      elseif TorteMe.sv.Zone.oldZoneId ~= 181 and TorteMe.sv.Zone.zoneId == 181 then
+      elseif TorteMe.sv.Zone.oldZoneId ~= TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.zoneId == TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 25)
       else
         TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 25)
       end
 
-    elseif TorteMe.sv.Zone.parentZoneId ~= 181 and TorteMe.sv.Zone.oldParentZoneId == 181 then
+    elseif TorteMe.sv.Zone.parentZoneId ~= TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL then
       TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
       TorteMe:Notify("Left Cyrodiil!")
       TorteMe:Log("Zoned OUT of Cyrodiil.", true, 5)
-      if TorteMe.sv.Zone.oldZoneId == 181 then
+      if TorteMe.sv.Zone.oldZoneId == TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " -> " .. TorteMe.sv.Zone.zoneName, true, 20)
-      elseif TorteMe.sv.Zone.oldZoneId ~=181 then
+      elseif TorteMe.sv.Zone.oldZoneId ~=TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. "(Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
       end
 
     else
       TorteMe:Log("Non-Cyrodiil Zone Detected.", true, 5)
-      if TorteMe.sv.Zone.oldParentZoneId == 181 and TorteMe.sv.Zone.oldZoneId ~= 181 then
+      if TorteMe.sv.Zone.oldParentZoneId == TorteMe.const.ZONEID_CYRODIIL and TorteMe.sv.Zone.oldZoneId ~= TorteMe.const.ZONEID_CYRODIIL then
         TorteMe:Log("Left Cyrodiil! - " .. TorteMe.displayName .. " disabled.")
         TorteMe:Log(TorteMe.sv.Zone.oldZoneName .. " (Cyrodiil) -> " .. TorteMe.sv.Zone.zoneName, true, 20)
       else

--- a/CreateSettingsWindow.lua
+++ b/CreateSettingsWindow.lua
@@ -23,7 +23,7 @@ function TorteMe.CreateSettingsWindow()
         end,
       setFunc = function(value)
           TorteMe.sv.HUD.enabled = value
-          if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
+          if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == TorteMe.const.ZONEID_CYRODIIL then
             TorteMeUI:SetHidden(not value)
           end
         end,

--- a/CreateSettingsWindow.lua
+++ b/CreateSettingsWindow.lua
@@ -1,23 +1,23 @@
 TorteMe = TorteMe or {}
 
 function TorteMe.CreateSettingsWindow()
-	local LAM = LibAddonMenu2
-	local panelName = TorteMe.name .. "SettingsPanel"
+  local LAM = LibAddonMenu2
+  local panelName = TorteMe.name .. "SettingsPanel"
 
-	local settingsWindowData = {
-		type = "panel",
-		name = TorteMe.displayName,
-		author = "|cff00ff@evainefaye|r",
-		version = TorteMe.version,
-		registerForRefresh = true,
-		registerForDefaults = true
-	}
+  local settingsWindowData = {
+    type = "panel",
+    name = TorteMe.displayName,
+    author = "|cff00ff@evainefaye|r",
+    version = TorteMe.version,
+    registerForRefresh = true,
+    registerForDefaults = true
+  }
 
-	local settingsOptionsData = {
+  local settingsOptionsData = {
     {
       type = "checkbox",
       name = "Enable HUD",
-			tooltip = "Turns on the HUD",
+      tooltip = "Turns on the HUD",
       getFunc = function()
           return TorteMe.sv.HUD.enabled
         end,
@@ -27,17 +27,17 @@ function TorteMe.CreateSettingsWindow()
             TorteMeUI:SetHidden(not value)
           end
         end,
-			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			reference = "TORTE_ME_HUD_ENABLE"
+      disabled = function() return not TorteMe.sv.Torte.enableTortes end,
+      reference = "TORTE_ME_HUD_ENABLE"
     },
     {
-			type = "header",
-			name = "War Tortes"
-		},
+      type = "header",
+      name = "War Tortes"
+    },
     {
       type = "checkbox",
       name = "Enable Tortes",
-			tooltip = "Enable tracking and eating of tortes while in Cyrodiil",
+      tooltip = "Enable tracking and eating of tortes while in Cyrodiil",
       getFunc = function()
           return TorteMe.sv.Torte.enableTortes
         end,
@@ -45,12 +45,12 @@ function TorteMe.CreateSettingsWindow()
           TorteMe.sv.Torte.enableTortes = value
           TorteMe:TorteBuffReminderLoop()
         end,
-			reference = "TORTE_ME_ENABLE_TORTES"
+      reference = "TORTE_ME_ENABLE_TORTES"
     },
-		{
+    {
       type = "checkbox",
       name = "Auto Consume",
-			tooltip = "Automatically eat tortes while in Cyrodiil",
+      tooltip = "Automatically eat tortes while in Cyrodiil",
       getFunc = function()
           return TorteMe.sv.Torte.autoConsume
         end,
@@ -58,48 +58,48 @@ function TorteMe.CreateSettingsWindow()
           TorteMe.sv.Torte.autoConsume = value
           TorteMe:TorteBuffReminderLoop()
         end,
-			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			reference = "TORTE_ME_TRACK_AUTO_CONSUME_TORTE"
+      disabled = function() return not TorteMe.sv.Torte.enableTortes end,
+      reference = "TORTE_ME_TRACK_AUTO_CONSUME_TORTE"
     },
-		{
-			type = "slider",
-			name = "Torte Buff Reminder Time",
-			tooltip = "How often to notify when out of tortes or needing to eat one.",
-			min = 1,
-			max = 30,
-			step = 1,
-			getFunc = function()
-				return TorteMe.sv.Torte.torteNotificationTime
-			end,
-			setFunc = function(value)
-				TorteMe.sv.Torte.torteNotificationTime = value
-			end,
-			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			reference = "TORTE_ME_TORTE_NOTIFICATION_TIME"
-		},
-		{
-			type = "slider",
-			name = "Low Torte Count",
-			tooltip = "How many tortes you can be down to before you will be notified.",
-			min = 0,
-			max = 100,
-			getFunc = function()
-				return TorteMe.sv.Torte.torteNotifyWhenBelow
-			end,
-			setFunc = function(value)
-				TorteMe.sv.Torte.torteNotifyWhenBelow = value
-			end,
-			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			reference = "TORTE_ME_TORTE_NOTIFY_WHEN_BELOW"
-		},
     {
-			type = "header",
-			name = "Delve Bonus"
-		},
+      type = "slider",
+      name = "Torte Buff Reminder Time",
+      tooltip = "How often to notify when out of tortes or needing to eat one.",
+      min = 1,
+      max = 30,
+      step = 1,
+      getFunc = function()
+        return TorteMe.sv.Torte.torteNotificationTime
+      end,
+      setFunc = function(value)
+        TorteMe.sv.Torte.torteNotificationTime = value
+      end,
+      disabled = function() return not TorteMe.sv.Torte.enableTortes end,
+      reference = "TORTE_ME_TORTE_NOTIFICATION_TIME"
+    },
+    {
+      type = "slider",
+      name = "Low Torte Count",
+      tooltip = "How many tortes you can be down to before you will be notified.",
+      min = 0,
+      max = 100,
+      getFunc = function()
+        return TorteMe.sv.Torte.torteNotifyWhenBelow
+      end,
+      setFunc = function(value)
+        TorteMe.sv.Torte.torteNotifyWhenBelow = value
+      end,
+      disabled = function() return not TorteMe.sv.Torte.enableTortes end,
+      reference = "TORTE_ME_TORTE_NOTIFY_WHEN_BELOW"
+    },
+    {
+      type = "header",
+      name = "Delve Bonus"
+    },
     {
       type = "checkbox",
       name = "Enable Delve Bonus Reminder",
-			tooltip = "Enable tracking Delve Bonus while in Cyrodiil",
+      tooltip = "Enable tracking Delve Bonus while in Cyrodiil",
       getFunc = function()
           return TorteMe.sv.Torte.enableDelves
         end,
@@ -107,57 +107,57 @@ function TorteMe.CreateSettingsWindow()
           TorteMe.sv.Torte.enableDelves = value
           TorteMe:DelveBonusReminderLoop()
         end,
-			reference = "TORTE_ME_ENABLE_DELVE_BONUS"
+      reference = "TORTE_ME_ENABLE_DELVE_BONUS"
     },
     {
-			type = "slider",
-			name = "Delve Bonus Reminder Time",
-			tooltip = "How often to notify when you should get a new delve bonus",
-			min = 0,
-			max = 30,
-			getFunc = function()
-				return TorteMe.sv.Torte.delveNotificationTime
-			end,
-			setFunc = function(value)
-				TorteMe.sv.Torte.delveNotificationTime = value
-			end,
-			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			reference = "TORTE_ME_DELVE_NOTIFICATION_TIME"
+      type = "slider",
+      name = "Delve Bonus Reminder Time",
+      tooltip = "How often to notify when you should get a new delve bonus",
+      min = 0,
+      max = 30,
+      getFunc = function()
+        return TorteMe.sv.Torte.delveNotificationTime
+      end,
+      setFunc = function(value)
+        TorteMe.sv.Torte.delveNotificationTime = value
+      end,
+      disabled = function() return not TorteMe.sv.Torte.enableTortes end,
+      reference = "TORTE_ME_DELVE_NOTIFICATION_TIME"
     },
     {
       type = "header",
       name = "Debug"
-		},
+    },
     {
-			type = "checkbox",
-			name = "Enable Debug",
-			tooltip = "Show Debug Messages",
-			getFunc = function()
+      type = "checkbox",
+      name = "Enable Debug",
+      tooltip = "Show Debug Messages",
+      getFunc = function()
           return TorteMe.sv.Debug.showDebug
         end,
-			setFunc = function(value)
+      setFunc = function(value)
           TorteMe.sv.Debug.showDebug = value
         end,
-			reference = "TORTE_ME_SHOW_DEBUG",
-			disabled = false
-		},
+      reference = "TORTE_ME_SHOW_DEBUG",
+      disabled = false
+    },
     {
-			type = "slider",
-			name = "Debug Level",
-			tooltip = "Verbosity of Debug Errors",
-			min = 1,
-			max = 100,
-			getFunc = function()
+      type = "slider",
+      name = "Debug Level",
+      tooltip = "Verbosity of Debug Errors",
+      min = 1,
+      max = 100,
+      getFunc = function()
           return TorteMe.sv.Debug.showDebugLevel
         end,
-			setFunc = function(value)
+      setFunc = function(value)
           TorteMe.sv.Debug.showDebugLevel = value
         end,
-			disabled = function() return not TorteMe.sv.Debug.showDebug end,
-			reference = "TORTE_ME_DEBUG_LEVEL"
+      disabled = function() return not TorteMe.sv.Debug.showDebug end,
+      reference = "TORTE_ME_DEBUG_LEVEL"
     }
-	}
+  }
 
-	TorteMe.settingsPanel = LAM:RegisterAddonPanel("TorteMe_LAM", settingsWindowData)
-	LAM:RegisterOptionControls("TorteMe_LAM", settingsOptionsData)
+  TorteMe.settingsPanel = LAM:RegisterAddonPanel("TorteMe_LAM", settingsWindowData)
+  LAM:RegisterOptionControls("TorteMe_LAM", settingsOptionsData)
 end

--- a/CreateSettingsWindow.lua
+++ b/CreateSettingsWindow.lua
@@ -28,7 +28,6 @@ function TorteMe.CreateSettingsWindow()
           end
         end,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			default = true,
 			reference = "TORTE_ME_HUD_ENABLE"
     },
     {
@@ -46,7 +45,6 @@ function TorteMe.CreateSettingsWindow()
           TorteMe.sv.Torte.enableTortes = value
           TorteMe:TorteBuffReminderLoop()
         end,
-			default = true,
 			reference = "TORTE_ME_ENABLE_TORTES"
     },
 		{
@@ -60,7 +58,6 @@ function TorteMe.CreateSettingsWindow()
           TorteMe.sv.Torte.autoConsume = value
           TorteMe:TorteBuffReminderLoop()
         end,
-			default = true,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_TRACK_AUTO_CONSUME_TORTE"
     },
@@ -77,7 +74,6 @@ function TorteMe.CreateSettingsWindow()
 			setFunc = function(value)
 				TorteMe.sv.Torte.torteNotificationTime = value
 			end,
-			default = 5,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_TORTE_NOTIFICATION_TIME"
 		},
@@ -93,7 +89,6 @@ function TorteMe.CreateSettingsWindow()
 			setFunc = function(value)
 				TorteMe.sv.Torte.torteNotifyWhenBelow = value
 			end,
-			default = 5,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_TORTE_NOTIFY_WHEN_BELOW"
 		},
@@ -112,7 +107,6 @@ function TorteMe.CreateSettingsWindow()
           TorteMe.sv.Torte.enableDelves = value
           TorteMe:DelveBonusReminderLoop()
         end,
-			default = true,
 			reference = "TORTE_ME_ENABLE_DELVE_BONUS"
     },
     {
@@ -127,7 +121,6 @@ function TorteMe.CreateSettingsWindow()
 			setFunc = function(value)
 				TorteMe.sv.Torte.delveNotificationTime = value
 			end,
-			default = 10,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_DELVE_NOTIFICATION_TIME"
     },
@@ -145,7 +138,6 @@ function TorteMe.CreateSettingsWindow()
 			setFunc = function(value)
           TorteMe.sv.Debug.showDebug = value
         end,
-			default = false,
 			reference = "TORTE_ME_SHOW_DEBUG",
 			disabled = false
 		},
@@ -161,7 +153,6 @@ function TorteMe.CreateSettingsWindow()
 			setFunc = function(value)
           TorteMe.sv.Debug.showDebugLevel = value
         end,
-			default = 50,
 			disabled = function() return not TorteMe.sv.Debug.showDebug end,
 			reference = "TORTE_ME_DEBUG_LEVEL"
     }

--- a/CreateSettingsWindow.lua
+++ b/CreateSettingsWindow.lua
@@ -2,7 +2,7 @@ TorteMe = TorteMe or {}
 
 function TorteMe.CreateSettingsWindow()
 	local LAM = LibAddonMenu2
-	local panelName = TorteMe.name .. "SettingsPanel" 
+	local panelName = TorteMe.name .. "SettingsPanel"
 
 	local settingsWindowData = {
 		type = "panel",
@@ -14,44 +14,40 @@ function TorteMe.CreateSettingsWindow()
 	}
 
 	local settingsOptionsData = {
-
-		[1] = {
+    {
 			type = "header",
 			name = "War Tortes"
 		},
-
-		[2] = {
-            type = "checkbox",
-            name = "Enable Tortes",
+    {
+      type = "checkbox",
+      name = "Enable Tortes",
 			tooltip = "Enable tracking and eating of tortes while in Cyrodiil",
-            getFunc = function()
-				return TorteMe.sv.Torte.enableTortes
-			end,
-            setFunc = function(value)
-				TorteMe.sv.Torte.enableTortes = value
-				TorteMe:TorteBuffReminderLoop()
-			end,
+      getFunc = function()
+          return TorteMe.sv.Torte.enableTortes
+        end,
+      setFunc = function(value)
+          TorteMe.sv.Torte.enableTortes = value
+          TorteMe:TorteBuffReminderLoop()
+        end,
 			default = true,
 			reference = "TORTE_ME_ENABLE_TORTES"
-        },
-		
-		[3] = {
-            type = "checkbox",
-            name = "Auto Consume",
+    },
+		{
+      type = "checkbox",
+      name = "Auto Consume",
 			tooltip = "Automatically eat tortes while in Cyrodiil",
-            getFunc = function()
-				return TorteMe.sv.Torte.autoConsume
-			end,
-            setFunc = function(value)
-				TorteMe.sv.Torte.autoConsume = value
-				TorteMe:TorteBuffReminderLoop()
-			end,
+      getFunc = function()
+          return TorteMe.sv.Torte.autoConsume
+        end,
+      setFunc = function(value)
+          TorteMe.sv.Torte.autoConsume = value
+          TorteMe:TorteBuffReminderLoop()
+        end,
 			default = true,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_TRACK_AUTO_CONSUME_TORTE"
-        },
-		
-		[4] = {
+    },
+		{
 			type = "slider",
 			name = "Torte Buff Reminder Time",
 			tooltip = "How often to notify when out of tortes or needing to eat one.",
@@ -68,8 +64,7 @@ function TorteMe.CreateSettingsWindow()
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_TORTE_NOTIFICATION_TIME"
 		},
-		
-		[5] = {
+		{
 			type = "slider",
 			name = "Low Torte Count",
 			tooltip = "How many tortes you can be down to before you will be notified.",
@@ -85,9 +80,7 @@ function TorteMe.CreateSettingsWindow()
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_TORTE_NOTIFY_WHEN_BELOW"
 		},
-
-		
-		[6] = {
+    {
 			type = "slider",
 			name = "Delve Bonus Reminder Time",
 			tooltip = "How often to notify when you should get a new delve bonus",
@@ -102,63 +95,58 @@ function TorteMe.CreateSettingsWindow()
 			default = 10,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_DELVE_NOTIFICATION_TIME"
-         },
-		
-		[7] = {
-            type = "checkbox",
-            name = "Enable HUD",
+    },
+    {
+      type = "checkbox",
+      name = "Enable HUD",
 			tooltip = "Turns on the HUD",
-            getFunc = function()
-				return TorteMe.sv.HUD.enabled
-			end,
-            setFunc = function(value)
-				TorteMe.sv.HUD.enabled = value
-				if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
-					TorteMeUI:SetHidden(not value)
-				end
-			end,
+      getFunc = function()
+          return TorteMe.sv.HUD.enabled
+        end,
+      setFunc = function(value)
+          TorteMe.sv.HUD.enabled = value
+          if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
+            TorteMeUI:SetHidden(not value)
+          end
+        end,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			default = true,
 			reference = "TORTE_ME_HUD_ENABLE"
-        },
-
-
-		[8] = {
-			type = "header",
-			name = "Debug"
+    },
+    {
+      type = "header",
+      name = "Debug"
 		},
-
-		[9] = {
+    {
 			type = "checkbox",
 			name = "Enable Debug",
 			tooltip = "Show Debug Messages",
 			getFunc = function()
-				return TorteMe.sv.Debug.showDebug
-			end,
+          return TorteMe.sv.Debug.showDebug
+        end,
 			setFunc = function(value)
-				TorteMe.sv.Debug.showDebug = value
-			end,
+          TorteMe.sv.Debug.showDebug = value
+        end,
 			default = false,
 			reference = "TORTE_ME_SHOW_DEBUG",
 			disabled = false
 		},
-
-		[10] = {
+    {
 			type = "slider",
 			name = "Debug Level",
 			tooltip = "Verbosity of Debug Errors",
 			min = 1,
 			max = 100,
 			getFunc = function()
-				return TorteMe.sv.Debug.showDebugLevel
-			end,
+          return TorteMe.sv.Debug.showDebugLevel
+        end,
 			setFunc = function(value)
-				TorteMe.sv.Debug.showDebugLevel = value
-			end,
+          TorteMe.sv.Debug.showDebugLevel = value
+        end,
 			default = 50,
 			disabled = function() return not TorteMe.sv.Debug.showDebug end,
 			reference = "TORTE_ME_DEBUG_LEVEL"
-         }
+    }
 	}
 
 	TorteMe.settingsPanel = LAM:RegisterAddonPanel("TorteMe_LAM", settingsWindowData)

--- a/CreateSettingsWindow.lua
+++ b/CreateSettingsWindow.lua
@@ -15,6 +15,23 @@ function TorteMe.CreateSettingsWindow()
 
 	local settingsOptionsData = {
     {
+      type = "checkbox",
+      name = "Enable HUD",
+			tooltip = "Turns on the HUD",
+      getFunc = function()
+          return TorteMe.sv.HUD.enabled
+        end,
+      setFunc = function(value)
+          TorteMe.sv.HUD.enabled = value
+          if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
+            TorteMeUI:SetHidden(not value)
+          end
+        end,
+			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
+			default = true,
+			reference = "TORTE_ME_HUD_ENABLE"
+    },
+    {
 			type = "header",
 			name = "War Tortes"
 		},
@@ -81,6 +98,24 @@ function TorteMe.CreateSettingsWindow()
 			reference = "TORTE_ME_TORTE_NOTIFY_WHEN_BELOW"
 		},
     {
+			type = "header",
+			name = "Delve Bonus"
+		},
+    {
+      type = "checkbox",
+      name = "Enable Delve Bonus Reminder",
+			tooltip = "Enable tracking Delve Bonus while in Cyrodiil",
+      getFunc = function()
+          return TorteMe.sv.Torte.enableDelves
+        end,
+      setFunc = function(value)
+          TorteMe.sv.Torte.enableDelves = value
+          TorteMe:DelveBonusReminderLoop()
+        end,
+			default = true,
+			reference = "TORTE_ME_ENABLE_DELVE_BONUS"
+    },
+    {
 			type = "slider",
 			name = "Delve Bonus Reminder Time",
 			tooltip = "How often to notify when you should get a new delve bonus",
@@ -95,23 +130,6 @@ function TorteMe.CreateSettingsWindow()
 			default = 10,
 			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
 			reference = "TORTE_ME_DELVE_NOTIFICATION_TIME"
-    },
-    {
-      type = "checkbox",
-      name = "Enable HUD",
-			tooltip = "Turns on the HUD",
-      getFunc = function()
-          return TorteMe.sv.HUD.enabled
-        end,
-      setFunc = function(value)
-          TorteMe.sv.HUD.enabled = value
-          if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
-            TorteMeUI:SetHidden(not value)
-          end
-        end,
-			disabled = function() return not TorteMe.sv.Torte.enableTortes end,
-			default = true,
-			reference = "TORTE_ME_HUD_ENABLE"
     },
     {
       type = "header",

--- a/EatTorte.lua
+++ b/EatTorte.lua
@@ -2,20 +2,20 @@ TorteMe = TorteMe or {}
 
 function TorteMe:EatTorte(torteSlot)
 
-	EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+  EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
 
-	if torteSlot >= 0 then
+  if torteSlot >= 0 then
 
-		local amISecure = CallSecureProtected("UseItem")
+    local amISecure = CallSecureProtected("UseItem")
 
-		if amISecure == true then
+    if amISecure == true then
 
-			if IsUnitInCombat("player") or IsUnitDeadOrReincarnating("player") or IsUnitSwimming("player") then
-			end
+      if IsUnitInCombat("player") or IsUnitDeadOrReincarnating("player") or IsUnitSwimming("player") then
+      end
 
-			CallSecureProtected("UseItem", BAG_BACKPACK, torteSlot)
-		end
-	end
-	EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop", 10000, function() TorteMe:TorteBuffReminderLoop() end)
+      CallSecureProtected("UseItem", BAG_BACKPACK, torteSlot)
+    end
+  end
+  EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop", 10000, function() TorteMe:TorteBuffReminderLoop() end)
 end
 

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -11,11 +11,11 @@ Return: isPlayerInCyrodiil bool
 --]]
 
 function TorteMe:IsPlayerInCyrodiil()
-	local isPlayerInCyrodiil = false
-	if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
-		isPlayerInCyrodiil = true
-	end
-	return isPlayerInCyrodiil
+  local isPlayerInCyrodiil = false
+  if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
+    isPlayerInCyrodiil = true
+  end
+  return isPlayerInCyrodiil
 end
 
 
@@ -33,31 +33,31 @@ Return: torteBuffInfo {torteBuffActive bool, buffId number, buffName string, buf
 
 function TorteMe:DoesPlayerHaveTorteBuff()
 
-	local torteBuffInfo = {
-		torteBuffActive = false,
-		torteBuffId = 0,
-		torteBuffName = "",
-		torteBuffEnding = 0
-	}
+  local torteBuffInfo = {
+    torteBuffActive = false,
+    torteBuffId = 0,
+    torteBuffName = "",
+    torteBuffEnding = 0
+  }
 
-	local numBuffs = GetNumBuffs("player")
-	if numBuffs > 0 then
-		for i = 1, numBuffs do
-			for j = 1, #TorteMe.torteBuffs do
-				local buffName,_, timeEnding,_,_,_,_,_,_,_,id = GetUnitBuffInfo("player", i)
-				TorteMe:Log("Checking " .. id .. " against " .. TorteMe.torteBuffs[j], true, 5)
-				if id == TorteMe.torteBuffs[j] then
-					torteBuffInfo.torteBuffActive = true
-					torteBuffInfo.torteBuffId = id
-					torteBuffInfo.torteBuffName = buffName
-					torteBuffInfo.torteBuffEnding = timeEnding
-					break
-				end
-			end
-			if torteBuffInfo.torteBuffActive == true then break end
-		end
-	end
-	return torteBuffInfo
+  local numBuffs = GetNumBuffs("player")
+  if numBuffs > 0 then
+    for i = 1, numBuffs do
+      for j = 1, #TorteMe.torteBuffs do
+        local buffName,_, timeEnding,_,_,_,_,_,_,_,id = GetUnitBuffInfo("player", i)
+        TorteMe:Log("Checking " .. id .. " against " .. TorteMe.torteBuffs[j], true, 5)
+        if id == TorteMe.torteBuffs[j] then
+          torteBuffInfo.torteBuffActive = true
+          torteBuffInfo.torteBuffId = id
+          torteBuffInfo.torteBuffName = buffName
+          torteBuffInfo.torteBuffEnding = timeEnding
+          break
+        end
+      end
+      if torteBuffInfo.torteBuffActive == true then break end
+    end
+  end
+  return torteBuffInfo
 end
 
 
@@ -75,67 +75,63 @@ Return: delveBonusInfo {delveBonusActive bool, buffId number, buffName string, b
 
 function TorteMe:DoesPlayerHaveDelveBonus()
 
-	local delveBonusInfo = {
-		delveBonusActive = false,
-		delveBonusId = 0,
-		delveBonusName = "",
-		delveBonusEnding = 0
-	}
+  local delveBonusInfo = {
+    delveBonusActive = false,
+    delveBonusId = 0,
+    delveBonusName = "",
+    delveBonusEnding = 0
+  }
 
-	local numBuffs = GetNumBuffs("player")
-	if numBuffs > 0 then
-		for i = 1, numBuffs do
-			for j = 1, #TorteMe.delveBonusBuffs do
-				local buffName,_, timeEnding,_,_,_,_,_,_,_,id = GetUnitBuffInfo("player", i)
-				TorteMe:Log("Checking " .. id .. " against " .. TorteMe.delveBonusBuffs[j], true, 5)
-				if id == TorteMe.delveBonusBuffs[j] then
-					delveBonusInfo.delveBonusActive = true
-					delveBonusInfo.delveBonusId = id
-					delveBonusInfo.delveBonusName = buffName
-					delveBonusInfo.delveBonusEnding = timeEnding
-					break
-				end
-			end
-			if delveBonusInfo.delveBonusActive == true then break end
-		end
-	end
-	return delveBonusInfo
+  local numBuffs = GetNumBuffs("player")
+  if numBuffs > 0 then
+    for i = 1, numBuffs do
+      for j = 1, #TorteMe.delveBonusBuffs do
+        local buffName,_, timeEnding,_,_,_,_,_,_,_,id = GetUnitBuffInfo("player", i)
+        TorteMe:Log("Checking " .. id .. " against " .. TorteMe.delveBonusBuffs[j], true, 5)
+        if id == TorteMe.delveBonusBuffs[j] then
+          delveBonusInfo.delveBonusActive = true
+          delveBonusInfo.delveBonusId = id
+          delveBonusInfo.delveBonusName = buffName
+          delveBonusInfo.delveBonusEnding = timeEnding
+          break
+        end
+      end
+      if delveBonusInfo.delveBonusActive == true then break end
+    end
+  end
+  return delveBonusInfo
 end
-
-
-
-
 
 --[[
 ************************************************************************************
 
-Searches bag(s) to see if you have torte(s) based on list provided in 
+Searches bag(s) to see if you have torte(s) based on list provided in
 
 Return: torteInventoryInfo {torteFound bool, torteSlot number}
-	
+
 ************************************************************************************
 --]]
 
 function TorteMe:DoesPlayerHaveTortes()
-	local torteInventoryInfo = {
-		torteFound = false,
-		torteSlot = -1
-	}
-	
-	for j = 1, #TorteMe.torteItems do
-		for slotId = 0, GetBagSize(BAG_BACKPACK) do
-			local bagItemId = GetItemId(BAG_BACKPACK, slotId)
-			if bagItemId == TorteMe.torteItems[j] then 
-				torteInventoryInfo.torteFound = true
-				torteInventoryInfo.torteSlot = slotId
-			end
-			if torteInventoryInfo.torteFound then
-				break
-			end
-		end
-	end
-	q = TorteMe:GetTotalTorteCount()
-	return torteInventoryInfo
+  local torteInventoryInfo = {
+    torteFound = false,
+    torteSlot = -1
+  }
+
+  for j = 1, #TorteMe.torteItems do
+    for slotId = 0, GetBagSize(BAG_BACKPACK) do
+      local bagItemId = GetItemId(BAG_BACKPACK, slotId)
+      if bagItemId == TorteMe.torteItems[j] then
+        torteInventoryInfo.torteFound = true
+        torteInventoryInfo.torteSlot = slotId
+      end
+      if torteInventoryInfo.torteFound then
+        break
+      end
+    end
+  end
+  q = TorteMe:GetTotalTorteCount()
+  return torteInventoryInfo
 end
 
 
@@ -145,32 +141,23 @@ end
 Searches bag(s) and gets a count of the total number of torte items you have.
 
 Return: totalTorteCount number
-	
+
 ************************************************************************************
 --]]
 
 function TorteMe:GetTotalTorteCount()
-	local totalTorteCount = 0
-	for j = 1, #TorteMe.torteItems do
-		for slotId = 0, GetBagSize(BAG_BACKPACK) do
-			local bagItemId = GetItemId(BAG_BACKPACK, slotId)
-			if bagItemId == TorteMe.torteItems[j] then 
-				local size = GetSlotStackSize(BAG_BACKPACK, slotId)
-				totalTorteCount = totalTorteCount + size
-			end
-		end
-	end
-	return totalTorteCount
+  local totalTorteCount = 0
+  for j = 1, #TorteMe.torteItems do
+    for slotId = 0, GetBagSize(BAG_BACKPACK) do
+      local bagItemId = GetItemId(BAG_BACKPACK, slotId)
+      if bagItemId == TorteMe.torteItems[j] then
+        local size = GetSlotStackSize(BAG_BACKPACK, slotId)
+        totalTorteCount = totalTorteCount + size
+      end
+    end
+  end
+  return totalTorteCount
 end
-
-
-
-
-
-
-
-
-
 
 --[[
 ************************************************************************************
@@ -183,10 +170,8 @@ Return: TorteMe.sv.Torte.autoConsume bool
 --]]
 
 function TorteMe:IsAutoConsumeEnabled()
-	return TorteMe.sv.Torte.autoConsume
+  return TorteMe.sv.Torte.autoConsume
 end
-
-
 
 --[[
 ************************************************************************************
@@ -194,57 +179,52 @@ end
 ************************************************************************************
 --]]
 
-
 function TorteMe.OnDelveBonusChanged( eventCode, changeType, effectSlot, effectName, unitTag, beginTime, endTime, stackCount, iconName, buffType, effectType, abilityType, statusEffectType, unitName, unitId, abilityId, sourceType )
-	if changeType == 1 then
-		TorteMe:Log("Delve Bonus Started: " .. effectName .. "endTime: " .. endTime, true, 10)
-		TorteMe:UpdateDelveHUD(effectName, endTime)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_DelveBonusReminderLoop")
-	end
-	
-	if changeType == 2 then 
-		TorteMe:Log("Delve Bonus Ended: " .. effectName, true, 10)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_DelveBonusReminderLoop")
-		TorteMe:DelveBonusReminderLoop()
-	end
+  if changeType == 1 then
+    TorteMe:Log("Delve Bonus Started: " .. effectName .. "endTime: " .. endTime, true, 10)
+    TorteMe:UpdateDelveHUD(effectName, endTime)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_DelveBonusReminderLoop")
+  end
+
+  if changeType == 2 then
+    TorteMe:Log("Delve Bonus Ended: " .. effectName, true, 10)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_DelveBonusReminderLoop")
+    TorteMe:DelveBonusReminderLoop()
+  end
 end
-	
+
 --[[
 ************************************************************************************
                               TORTE BUFF EVENTS
 ************************************************************************************
 --]]
 
-
 function TorteMe.OnTorteBuffChanged( eventCode, changeType, effectSlot, effectName, unitTag, beginTime, endTime, stackCount, iconName, buffType, effectType, abilityType, statusEffectType, unitName, unitId, abilityId, sourceType )
-	--Buff Started
-	local torteCount = 0
-	if changeType == 1 then
-		TorteMe:Log("Buff Started: " .. effectName .. " endTime: " .. endTime, true, 10)
-		TorteMe:UpdateTorteHUD(effectName, endTime)
-		
-		
-		local totalTorteCount = TorteMe:GetTotalTorteCount()
-		if totalTorteCount <  TorteMe.sv.Torte.torteNotifyWhenBelow and totalTorteCount > 0 then
-			TorteMe:Log("|cffff00You have |cff0000" .. totalTorteCount .. "|cffff00 War Torte(s) remaining.|r")
-			TorteMe:Notify("|cffff00You have |cff0000" .. totalTorteCount .. "|cffff00 War Torte(s) remaining|r")
-		elseif totalTorteCount == 0 then 
-			TorteMe:Log(TorteMe.torteInventoryReminderText)
-			TorteMe:Notify(TorteMe.torteInventoryReminderText)
-		end
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-	end
+  --Buff Started
+  local torteCount = 0
+  if changeType == 1 then
+    TorteMe:Log("Buff Started: " .. effectName .. " endTime: " .. endTime, true, 10)
+    TorteMe:UpdateTorteHUD(effectName, endTime)
 
-	--Buff Ended
-	if changeType == 2 then 
-		TorteMe:Log("Buff Ended: " .. effectName, true, 10)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		TorteMe:TorteBuffReminderLoop()
-	end
+
+    local totalTorteCount = TorteMe:GetTotalTorteCount()
+    if totalTorteCount <  TorteMe.sv.Torte.torteNotifyWhenBelow and totalTorteCount > 0 then
+      TorteMe:Log("|cffff00You have |cff0000" .. totalTorteCount .. "|cffff00 War Torte(s) remaining.|r")
+      TorteMe:Notify("|cffff00You have |cff0000" .. totalTorteCount .. "|cffff00 War Torte(s) remaining|r")
+    elseif totalTorteCount == 0 then
+      TorteMe:Log(TorteMe.torteInventoryReminderText)
+      TorteMe:Notify(TorteMe.torteInventoryReminderText)
+    end
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+  end
+
+  --Buff Ended
+  if changeType == 2 then
+    TorteMe:Log("Buff Ended: " .. effectName, true, 10)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    TorteMe:TorteBuffReminderLoop()
+  end
 end
-
-
-
 
 --[[
 ************************************************************************************
@@ -252,46 +232,44 @@ end
 ************************************************************************************
 --]]
 
-
 function TorteMe.OnInventoryUpdate(eventCode, bagId, slotIndex, isNewItem, itemSoundCategory, updateReason, stackCountChange)
-	-- Only process inventory changes in your own bag
-	
-	if TorteMe.loopType == "inventory" then
-		local isTorte = false
-		local totalTorteCount = TorteMe:GetTotalTorteCount()
-		if stackCountChange > 0 and bagId ==1 then
-			for j = 1, #TorteMe.torteItems do
-				local itemId = GetItemId(bagId, slotIndex)
-				if itemId == TorteMe.torteItems[j]  then
-					isTorte = true
-					break
-				end
-			end
-			if (totalTorteCount - stackCountChange == 0) then
-				TorteMe:Log("You now have War Torte(s).")
-				TorteMe:Notify("You now have War Torte(s)")
-			end
-			if isTorte == true then
-				TorteMe:TorteBuffReminderLoop()
-				return
-			end
-		end
-	end
-	if TorteMe.loopType == "eat" then
-		if stackCountChange < 0 and bagId == 1 then
-			local totalTorteCount = TorteMe:GetTotalTorteCount()
-			if totalTorteCount == 0 then	
-			torteBuffInfo = TorteMe:DoesPlayerHaveTorteBuff()
-				if torteBuffInfo.torteBuffActive == false then
-					TorteMe.loopType = "inventory"		
-					TorteMe:TorteBuffReminderLoop()
-					return
-				end
-			end
-		end
-	end
-end
+  -- Only process inventory changes in your own bag
 
+  if TorteMe.loopType == "inventory" then
+    local isTorte = false
+    local totalTorteCount = TorteMe:GetTotalTorteCount()
+    if stackCountChange > 0 and bagId ==1 then
+      for j = 1, #TorteMe.torteItems do
+        local itemId = GetItemId(bagId, slotIndex)
+        if itemId == TorteMe.torteItems[j]  then
+          isTorte = true
+          break
+        end
+      end
+      if (totalTorteCount - stackCountChange == 0) then
+        TorteMe:Log("You now have War Torte(s).")
+        TorteMe:Notify("You now have War Torte(s)")
+      end
+      if isTorte == true then
+        TorteMe:TorteBuffReminderLoop()
+        return
+      end
+    end
+  end
+  if TorteMe.loopType == "eat" then
+    if stackCountChange < 0 and bagId == 1 then
+      local totalTorteCount = TorteMe:GetTotalTorteCount()
+      if totalTorteCount == 0 then
+      torteBuffInfo = TorteMe:DoesPlayerHaveTorteBuff()
+        if torteBuffInfo.torteBuffActive == false then
+          TorteMe.loopType = "inventory"
+          TorteMe:TorteBuffReminderLoop()
+          return
+        end
+      end
+    end
+  end
+end
 
 --[[
 ************************************************************************************
@@ -300,13 +278,13 @@ end
 --]]
 
 function TorteMe:Log(message, isDebug, debugLevel)
-	if TorteMe.sv.Debug.showDebug == true and debugLevel ~= nil and isDebug then
-		if TorteMe.sv.Debug.showDebugLevel  <= debugLevel then
-			df("|cffff00[ |cf21000DEBUG %s |c22ffed%s|cffff00] |c22ffed%s|r", GetTimeStamp(), TorteMe.displayName, tostring(message))
-		end
-	elseif isDebug == false or isDebug == nil then
-		df("|cffff00[ |c22ffed%s |cffff00] |c22ffed%s|r", TorteMe.displayName, tostring(message))
-	end
+  if TorteMe.sv.Debug.showDebug == true and debugLevel ~= nil and isDebug then
+    if TorteMe.sv.Debug.showDebugLevel  <= debugLevel then
+      df("|cffff00[ |cf21000DEBUG %s |c22ffed%s|cffff00] |c22ffed%s|r", GetTimeStamp(), TorteMe.displayName, tostring(message))
+    end
+  elseif isDebug == false or isDebug == nil then
+    df("|cffff00[ |c22ffed%s |cffff00] |c22ffed%s|r", TorteMe.displayName, tostring(message))
+  end
 end
 
 
@@ -317,16 +295,16 @@ end
 --]]
 
 function TorteMe:DumpTable(table, tableName, isDebug, showOnScreen, debugLevel)
-	if TorteMe.sv.Debug.showDebug == true and debugLevel ~= nil and isDebug then 
-		if TorteMe.sv.Debug.showDebugLevel  <= debugLevel then		
-			TorteMe:Log("*** START TABLE DUMP ***", true, TorteMe.sv.Debug.showDebugLevel)
-			TorteMe:Log("Table: |cffff00" ..  tableName .. "|r", true, TorteMe.sv.Debug.showDebugLevel)
-			for key,value in pairs(table) do
-				TorteMe:Log(key .. " |cffff00" .. tostring(value) .. "|r", true, TorteMe.sv.Debug.showDebugLevel)
-			end
-			TorteMe:Log("*** END TABLE DUMP ***", true, TorteMe.sv.Debug.showDebugLevel)
-		end
-	end
+  if TorteMe.sv.Debug.showDebug == true and debugLevel ~= nil and isDebug then
+    if TorteMe.sv.Debug.showDebugLevel  <= debugLevel then
+      TorteMe:Log("*** START TABLE DUMP ***", true, TorteMe.sv.Debug.showDebugLevel)
+      TorteMe:Log("Table: |cffff00" ..  tableName .. "|r", true, TorteMe.sv.Debug.showDebugLevel)
+      for key,value in pairs(table) do
+        TorteMe:Log(key .. " |cffff00" .. tostring(value) .. "|r", true, TorteMe.sv.Debug.showDebugLevel)
+      end
+      TorteMe:Log("*** END TABLE DUMP ***", true, TorteMe.sv.Debug.showDebugLevel)
+    end
+  end
 end
 
 --[[
@@ -335,21 +313,21 @@ end
 ************************************************************************************
 --]]
 
-function TorteMe:CancelCyrodiilTorteEvents() 
-	if TorteMe.torteEventsInitialized == true then
-		TorteMe:Log("Cancelling Cyrodiil Delve Bonus Events", true, 20)
-		for j = 1, #TorteMe.delveBonusBuffs do
-			EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED)
-		end
-		TorteMe:Log("Cancelling Cyrodiil Torte Events", true, 20)
-		for j = 1, #TorteMe.torteBuffs do
-			EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED)
-		end
-		EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_InventoryEvent", EVENT_INVENTORY_SINGLE_SLOT_UPDATE)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		TorteMe.torteEventsInitialized = false
-		TorteMe.torteloopType = "none"
-	end
+function TorteMe:CancelCyrodiilTorteEvents()
+  if TorteMe.torteEventsInitialized == true then
+    TorteMe:Log("Cancelling Cyrodiil Delve Bonus Events", true, 20)
+    for j = 1, #TorteMe.delveBonusBuffs do
+      EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED)
+    end
+    TorteMe:Log("Cancelling Cyrodiil Torte Events", true, 20)
+    for j = 1, #TorteMe.torteBuffs do
+      EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED)
+    end
+    EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_InventoryEvent", EVENT_INVENTORY_SINGLE_SLOT_UPDATE)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    TorteMe.torteEventsInitialized = false
+    TorteMe.torteloopType = "none"
+  end
 end
 
 
@@ -359,181 +337,175 @@ end
 ************************************************************************************
 --]]
 
-function TorteMe:InitializeCyrodiilTorteEvents() 
-	if 	TorteMe.torteEventsInitialized == false then
-		TorteMe:Log("Initializing Cyrodiil Delve Bonus Events", true, 20)
-		for j = 1, #TorteMe.delveBonusBuffs do
-			EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED)
-			EVENT_MANAGER:RegisterForEvent(TorteMe.name ..   "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED, TorteMe.OnDelveBonusChanged)			
-			EVENT_MANAGER:AddFilterForEvent(TorteMe.name ..  "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_UNIT_TAG, "player")
-			EVENT_MANAGER:AddFilterForEvent(TorteMe.name ..  "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_ABILITY_ID, TorteMe.delveBonusBuffs[j])
-		end
-	
-		TorteMe:Log("Initializing Cyrodiil Torte Events", true, 20)
-		for j = 1, #TorteMe.torteBuffs do
-			EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED)
-			EVENT_MANAGER:RegisterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED, TorteMe.OnTorteBuffChanged)			
-			EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_UNIT_TAG, "player")
-			EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_ABILITY_ID, TorteMe.torteBuffs[j])
-		end
-		EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE)
-		EVENT_MANAGER:RegisterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, TorteMe.OnInventoryUpdate)
-		EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, REGISTER_FILTER_BAG_ID, BAG_BACKPACK)
-		EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, REGISTER_FILTER_INVENTORY_UPDATE_REASON, INVENTORY_UPDATE_REASON_DEFAULT)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		TorteMe.torteEventsInitialized = true
-		TorteMe.loopType = "none"
-	end
+function TorteMe:InitializeCyrodiilTorteEvents()
+  if   TorteMe.torteEventsInitialized == false then
+    TorteMe:Log("Initializing Cyrodiil Delve Bonus Events", true, 20)
+    for j = 1, #TorteMe.delveBonusBuffs do
+      EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED)
+      EVENT_MANAGER:RegisterForEvent(TorteMe.name ..   "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED, TorteMe.OnDelveBonusChanged)
+      EVENT_MANAGER:AddFilterForEvent(TorteMe.name ..  "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_UNIT_TAG, "player")
+      EVENT_MANAGER:AddFilterForEvent(TorteMe.name ..  "_DelveBonusEvent_" .. TorteMe.delveBonusBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_ABILITY_ID, TorteMe.delveBonusBuffs[j])
+    end
+
+    TorteMe:Log("Initializing Cyrodiil Torte Events", true, 20)
+    for j = 1, #TorteMe.torteBuffs do
+      EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED)
+      EVENT_MANAGER:RegisterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED, TorteMe.OnTorteBuffChanged)
+      EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_UNIT_TAG, "player")
+      EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_TorteBuffEvent_" .. TorteMe.torteBuffs[j], EVENT_EFFECT_CHANGED, REGISTER_FILTER_ABILITY_ID, TorteMe.torteBuffs[j])
+    end
+    EVENT_MANAGER:UnregisterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE)
+    EVENT_MANAGER:RegisterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, TorteMe.OnInventoryUpdate)
+    EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, REGISTER_FILTER_BAG_ID, BAG_BACKPACK)
+    EVENT_MANAGER:AddFilterForEvent(TorteMe.name .. "_InventoryEvent_BACK_PACK", EVENT_INVENTORY_SINGLE_SLOT_UPDATE, REGISTER_FILTER_INVENTORY_UPDATE_REASON, INVENTORY_UPDATE_REASON_DEFAULT)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    TorteMe.torteEventsInitialized = true
+    TorteMe.loopType = "none"
+  end
 end
 
 
 
 --[[
 ************************************************************************************
-                                DELVE BONUS REMINDER LOOP 
+                                DELVE BONUS REMINDER LOOP
 ************************************************************************************
 --]]
 
 
 function TorteMe:DelveBonusReminderLoop()
-	local delveNotificationTime = (TorteMe.sv.Torte.delveNotificationTime * 60 * 1000)
+  local delveNotificationTime = (TorteMe.sv.Torte.delveNotificationTime * 60 * 1000)
 
-	local isPlayerInCyrodiil = TorteMe:IsPlayerInCyrodiil()
-	local delveBonusInfo = TorteMe:DoesPlayerHaveDelveBonus()
-
-	
-	TorteMe:Log("Entering Delve Bonus Reminder Loop", true, 25)
-	TorteMe:Log("Is Player In Cyrodiil: " .. tostring(isPlayerInCyrodiil), true, 15)
-	TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 15)
-	if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == false and TorteMe.torteEventsInitialized == true then
-		TorteMe:CancelCyrodiilTorteEvents()
-		return
-	end
-
-	-- If your in cyrodiil have enable tortes turned on but have not initalized the events then do so now.
-	if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == false then
-		TorteMe:Log("Catch In Cyrodiil without initalizing events", true, 15)
-		TorteMe:InitializeCyrodiilTorteEvents()
-	end
-	
-	
-	--*** SHOULD NOT LOOP ***
-
-	--Not in Cyrodiil or tortes are turned off safeguard, cancel events, set loop type to none and return
-	if isPlayerInCyrodiil == false or TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == true then
-		TorteMe:Log("Catch Exited of Cyrodiil without cancelling events", true, 15)
-		TorteMe:CancelCyrodiilTorteEvents() 
-		return
-	end
-	
-	--You have the buff currently dont need to do anything.
-	if delveBonusInfo.delveBonusActive == true then
-		TorteMe:Log("You have the delve bonus, " .. delveBonusInfo.delveBonusName .. ", so cancelling loop.", true, 20)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_delveBonusReminderLoop")
-		return
-	end
+  local isPlayerInCyrodiil = TorteMe:IsPlayerInCyrodiil()
+  local delveBonusInfo = TorteMe:DoesPlayerHaveDelveBonus()
 
 
-	if delveBonusInfo.delveBonusActive == false then 
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_delveBonusReminderLoop")
-		if TorteMe.sv.Torte.delveNotificationTime > 0 then 
-			TorteMe:Log(TorteMe.delveBonusExpiredText)
-			TorteMe:Notify(TorteMe.delveBonusExpiredText)
-		else
-			delveNotificationTime = 60 * 1000
-		end
-	end
-	EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_delveBonusReminderLoop", delveNotificationTime, function() TorteMe:DelveBonusReminderLoop() end)
+  TorteMe:Log("Entering Delve Bonus Reminder Loop", true, 25)
+  TorteMe:Log("Is Player In Cyrodiil: " .. tostring(isPlayerInCyrodiil), true, 15)
+  TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 15)
+  if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == false and TorteMe.torteEventsInitialized == true then
+    TorteMe:CancelCyrodiilTorteEvents()
+    return
+  end
+
+  -- If your in cyrodiil have enable tortes turned on but have not initalized the events then do so now.
+  if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == false then
+    TorteMe:Log("Catch In Cyrodiil without initalizing events", true, 15)
+    TorteMe:InitializeCyrodiilTorteEvents()
+  end
+
+
+  --*** SHOULD NOT LOOP ***
+
+  --Not in Cyrodiil or tortes are turned off safeguard, cancel events, set loop type to none and return
+  if isPlayerInCyrodiil == false or TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == true then
+    TorteMe:Log("Catch Exited of Cyrodiil without cancelling events", true, 15)
+    TorteMe:CancelCyrodiilTorteEvents()
+    return
+  end
+
+  --You have the buff currently dont need to do anything.
+  if delveBonusInfo.delveBonusActive == true then
+    TorteMe:Log("You have the delve bonus, " .. delveBonusInfo.delveBonusName .. ", so cancelling loop.", true, 20)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_delveBonusReminderLoop")
+    return
+  end
+
+
+  if delveBonusInfo.delveBonusActive == false then
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_delveBonusReminderLoop")
+    if TorteMe.sv.Torte.delveNotificationTime > 0 then
+      TorteMe:Log(TorteMe.delveBonusExpiredText)
+      TorteMe:Notify(TorteMe.delveBonusExpiredText)
+    else
+      delveNotificationTime = 60 * 1000
+    end
+  end
+  EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_delveBonusReminderLoop", delveNotificationTime, function() TorteMe:DelveBonusReminderLoop() end)
 end
-
-
-
-
-
 
 --[[
 ************************************************************************************
-                                TORTE BUFF REMINDER LOOP 
+                                TORTE BUFF REMINDER LOOP
 ************************************************************************************
 --]]
 
-
 function TorteMe:TorteBuffReminderLoop()
 
-	local torteNotificationTime = (TorteMe.sv.Torte.torteNotificationTime * 60 * 1000)
+  local torteNotificationTime = (TorteMe.sv.Torte.torteNotificationTime * 60 * 1000)
 
-	local isPlayerInCyrodiil = TorteMe:IsPlayerInCyrodiil()
-	local torteInventoryInfo = TorteMe:DoesPlayerHaveTortes()
-	local torteBuffInfo = TorteMe:DoesPlayerHaveTorteBuff()
-	local autoConsume = TorteMe:IsAutoConsumeEnabled()
-	
-	TorteMe:Log("Entering Torte Buff Reminder Loop", true, 25)
-	TorteMe:Log("Is Player In Cyrodiil: " .. tostring(isPlayerInCyrodiil), true, 15)
-	TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 15)
-	TorteMe:DumpTable(torteInventoryInfo, "torteInventoryInfo", true, 10)
-	TorteMe:DumpTable(torteBuffInfo, "torteBuffInfo", true, 10)
-	TorteMe:Log("autoConsume: " .. tostring(autoConsume), true,15)
-	
-	if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == false and TorteMe.torteEventsInitialized == true then
-		TorteMe:CancelCyrodiilTorteEvents()
-		return
-	end
+  local isPlayerInCyrodiil = TorteMe:IsPlayerInCyrodiil()
+  local torteInventoryInfo = TorteMe:DoesPlayerHaveTortes()
+  local torteBuffInfo = TorteMe:DoesPlayerHaveTorteBuff()
+  local autoConsume = TorteMe:IsAutoConsumeEnabled()
 
-	-- If your in cyrodiil have enable tortes turned on but have not initalized the events then do so now.
-	if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == false then
-		TorteMe:Log("Catch In Cyrodiil without initalizing events", true, 15)
-		TorteMe:InitializeCyrodiilTorteEvents()
-	end
-	
-	
-	--*** SHOULD NOT LOOP ***
+  TorteMe:Log("Entering Torte Buff Reminder Loop", true, 25)
+  TorteMe:Log("Is Player In Cyrodiil: " .. tostring(isPlayerInCyrodiil), true, 15)
+  TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 15)
+  TorteMe:DumpTable(torteInventoryInfo, "torteInventoryInfo", true, 10)
+  TorteMe:DumpTable(torteBuffInfo, "torteBuffInfo", true, 10)
+  TorteMe:Log("autoConsume: " .. tostring(autoConsume), true,15)
 
-	--Not in Cyrodiil or tortes are turned off safeguard, cancel events, set loop type to none and return
-	if isPlayerInCyrodiil == false or TorteMe.enableTortes == true and TorteMe.torteEventsInitialized == true then
-		TorteMe:Log("Catch Exited of Cyrodiil without cancelling events", true, 15)
-		TorteMe:CancelCyrodiilTorteEvents() 
-		return
-	end
-	
-	--You have the buff currently dont need to do anything.
-	if torteBuffInfo.torteBuffActive == true then
-		TorteMe:Log("You have the torte buff, " .. torteBuffInfo.torteBuffName .. ", so cancelling loop.", true, 20)
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		TorteMe.loopType = "none"
-		return
-	end
+  if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == false and TorteMe.torteEventsInitialized == true then
+    TorteMe:CancelCyrodiilTorteEvents()
+    return
+  end
 
-	
-	--AutoConsume Enabled so call the eat routine the eat routine has its own timers to try to eat but will call the buff reminder loop each time to check for other issues. such as having run out of tortes turning off auto consume, etc.
-	if torteBuffInfo.torteBuffActive == false and torteInventoryInfo.torteFound == true and autoConsume == true then
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		local reminderText = TorteMe.torteInventoryReminderText
-		-- *** Try to Eat ***
-		TorteMe:EatTorte(torteInventoryInfo.torteSlot)
-		return
-	end
+  -- If your in cyrodiil have enable tortes turned on but have not initalized the events then do so now.
+  if isPlayerInCyrodiil == true and TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == false then
+    TorteMe:Log("Catch In Cyrodiil without initalizing events", true, 15)
+    TorteMe:InitializeCyrodiilTorteEvents()
+  end
 
 
-	-- *** LOOP NOTICE ***
-	-- *** Notify you are out of tortes
-	if torteBuffInfo.torteBuffActive == false and torteInventoryInfo.torteFound == false then 
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		TorteMe:Log(TorteMe.torteInventoryReminderText)
-		TorteMe:Notify(TorteMe.torteInventoryReminderText)
-		TorteMe.loopType = "inventory"
-	end
+  --*** SHOULD NOT LOOP ***
 
-	-- *** Notify you need to try to eat ***
-	if torteBuffInfo.torteBuffActive == false and torteInventoryInfo.torteFound == true and autoConsume == false then
-		EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
-		TorteMe:Log(TorteMe.torteBuffReminderText)
-		TorteMe:Notify(TorteMe.torteBuffReminderText)
-		TorteMe.loopType = "eat"
-	end
+  --Not in Cyrodiil or tortes are turned off safeguard, cancel events, set loop type to none and return
+  if isPlayerInCyrodiil == false or TorteMe.enableTortes == true and TorteMe.torteEventsInitialized == true then
+    TorteMe:Log("Catch Exited of Cyrodiil without cancelling events", true, 15)
+    TorteMe:CancelCyrodiilTorteEvents()
+    return
+  end
 
-	if TorteMe.loopType == "inventory" or TorteMe.loopType == "eat" then
-		EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop", torteNotificationTime, function() TorteMe:TorteBuffReminderLoop() end)
-	end
+  --You have the buff currently dont need to do anything.
+  if torteBuffInfo.torteBuffActive == true then
+    TorteMe:Log("You have the torte buff, " .. torteBuffInfo.torteBuffName .. ", so cancelling loop.", true, 20)
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    TorteMe.loopType = "none"
+    return
+  end
+
+
+  --AutoConsume Enabled so call the eat routine the eat routine has its own timers to try to eat but will call the buff reminder loop each time to check for other issues. such as having run out of tortes turning off auto consume, etc.
+  if torteBuffInfo.torteBuffActive == false and torteInventoryInfo.torteFound == true and autoConsume == true then
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    local reminderText = TorteMe.torteInventoryReminderText
+    -- *** Try to Eat ***
+    TorteMe:EatTorte(torteInventoryInfo.torteSlot)
+    return
+  end
+
+
+  -- *** LOOP NOTICE ***
+  -- *** Notify you are out of tortes
+  if torteBuffInfo.torteBuffActive == false and torteInventoryInfo.torteFound == false then
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    TorteMe:Log(TorteMe.torteInventoryReminderText)
+    TorteMe:Notify(TorteMe.torteInventoryReminderText)
+    TorteMe.loopType = "inventory"
+  end
+
+  -- *** Notify you need to try to eat ***
+  if torteBuffInfo.torteBuffActive == false and torteInventoryInfo.torteFound == true and autoConsume == false then
+    EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop")
+    TorteMe:Log(TorteMe.torteBuffReminderText)
+    TorteMe:Notify(TorteMe.torteBuffReminderText)
+    TorteMe.loopType = "eat"
+  end
+
+  if TorteMe.loopType == "inventory" or TorteMe.loopType == "eat" then
+    EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_torteBuffReminderLoop", torteNotificationTime, function() TorteMe:TorteBuffReminderLoop() end)
+  end
 end
 
 
@@ -543,69 +515,68 @@ end
 --]]
 
 function TorteMe:TimeRemaining(timeEnd)
-	local timeSec = zo_max(zo_roundToNearest(timeEnd - GetGameTimeMilliseconds() / 1000, 1), 0)
-	local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
-	return timeSec, timeStr
+  local timeSec = zo_max(zo_roundToNearest(timeEnd - GetGameTimeMilliseconds() / 1000, 1), 0)
+  local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
+  return timeSec, timeStr
 end
-
 
 --[[
 *************************************************************************************************************************
-	            UPDATE TORTE HUD
+              UPDATE TORTE HUD
 *************************************************************************************************************************
 --]]
 function TorteMe:UpdateTorteHUD(buffName, timeEnd)
-	local timeSec = zo_max(zo_roundToNearest(timeEnd - GetGameTimeMilliseconds() / 1000, 1), 0)
-	local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
-	TorteMeUITorteBuffTime:SetText(timeStr)
-	TorteMeUITorteBuffTime:SetColor(0,255,0,255)	
-	EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_TorteTimer", 1000, function () 
-		timeSec = timeSec -1
-		if timeSec > 0 then
-			if timeSec > 180 then
-				TorteMeUITorteBuffTime:SetColor(0,255,0,255)
-			end
-			local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
-			TorteMeUITorteBuffTime:SetText(timeStr)
-			if timeSec < 181 then
-				TorteMeUITorteBuffTime:SetColor(255,255,0,255)
-			end
-		else 
-			TorteMeUITorteBuffTime:SetText("EXPIRED")
-			TorteMeUITorteBuffTime:SetColor(255,0,0,255)
-			EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_TorteTimer")
-		end
-	end)
+  local timeSec = zo_max(zo_roundToNearest(timeEnd - GetGameTimeMilliseconds() / 1000, 1), 0)
+  local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
+  TorteMeUITorteBuffTime:SetText(timeStr)
+  TorteMeUITorteBuffTime:SetColor(0,255,0,255)
+  EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_TorteTimer", 1000, function ()
+    timeSec = timeSec -1
+    if timeSec > 0 then
+      if timeSec > 180 then
+        TorteMeUITorteBuffTime:SetColor(0,255,0,255)
+      end
+      local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
+      TorteMeUITorteBuffTime:SetText(timeStr)
+      if timeSec < 181 then
+        TorteMeUITorteBuffTime:SetColor(255,255,0,255)
+      end
+    else
+      TorteMeUITorteBuffTime:SetText("EXPIRED")
+      TorteMeUITorteBuffTime:SetColor(255,0,0,255)
+      EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_TorteTimer")
+    end
+  end)
 end
 
 
 --[[
 *************************************************************************************************************************
-	            UPDATE DELVE HUD
+              UPDATE DELVE HUD
 *************************************************************************************************************************
 --]]
 function TorteMe:UpdateDelveHUD(buffName, timeEnd)
-	local timeSec = zo_max(zo_roundToNearest(timeEnd - GetGameTimeMilliseconds() / 1000, 1), 0)
-	local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
-	TorteMeUIDelveBonusTime:SetText(timeStr)
-	TorteMeUIDelveBonusTime:SetColor(0,255,0,255)	
-	EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_DelveTimer", 1000, function () 
-		timeSec = timeSec -1
-		if timeSec > 0 then
-			if timeSec > 180 then
-				TorteMeUIDelveBonusTime:SetColor(0,255,0,255)
-			end
-			local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
-			TorteMeUIDelveBonusTime:SetText(timeStr)
-			if timeSec < 181 then
-				TorteMeUIDelveBonusTime:SetColor(255,255,0,255)
-			end
-		else 
-			TorteMeUIDelveBonusTime:SetText("EXPIRED")
-			TorteMeUIDelveBonusTime:SetColor(255,0,0,255)
-			EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_DelveTimer")
-		end
-	end)
+  local timeSec = zo_max(zo_roundToNearest(timeEnd - GetGameTimeMilliseconds() / 1000, 1), 0)
+  local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
+  TorteMeUIDelveBonusTime:SetText(timeStr)
+  TorteMeUIDelveBonusTime:SetColor(0,255,0,255)
+  EVENT_MANAGER:RegisterForUpdate(TorteMe.name .. "_DelveTimer", 1000, function ()
+    timeSec = timeSec -1
+    if timeSec > 0 then
+      if timeSec > 180 then
+        TorteMeUIDelveBonusTime:SetColor(0,255,0,255)
+      end
+      local timeStr = FormatTimeSeconds(timeSec, TIME_FORMAT_STYLE_DESCRIPTIVE_MINIMAL, TIME_FORMAT_PRECISION_SECONDS, TIME_FORMAT_DIRECTION_DESCENDING)
+      TorteMeUIDelveBonusTime:SetText(timeStr)
+      if timeSec < 181 then
+        TorteMeUIDelveBonusTime:SetColor(255,255,0,255)
+      end
+    else
+      TorteMeUIDelveBonusTime:SetText("EXPIRED")
+      TorteMeUIDelveBonusTime:SetColor(255,0,0,255)
+      EVENT_MANAGER:UnregisterForUpdate(TorteMe.name .. "_DelveTimer")
+    end
+  end)
 end
 
 
@@ -616,10 +587,10 @@ Displays a message in the middle of the screen
 --]]
 
 function TorteMe:Notify(message)
-	local messageParams = CENTER_SCREEN_ANNOUNCE:CreateMessageParams(CSA_CATEGORY_SMALL_TEXT, SOUNDS.NONE)
-	messageParams:SetText("|cffff00" .. message .. "|r")
-	messageParams:SetLifespanMS(5000)
-	CENTER_SCREEN_ANNOUNCE:AddMessageWithParams(messageParams)
+  local messageParams = CENTER_SCREEN_ANNOUNCE:CreateMessageParams(CSA_CATEGORY_SMALL_TEXT, SOUNDS.NONE)
+  messageParams:SetText("|cffff00" .. message .. "|r")
+  messageParams:SetLifespanMS(5000)
+  CENTER_SCREEN_ANNOUNCE:AddMessageWithParams(messageParams)
 end
 
 
@@ -635,8 +606,8 @@ function TorteMe.OnIndicatorMoveStop()
 end
 
 function TorteMe.OnResizeStop()
-	TorteMe.sv.HUD.width = TorteMeUI:GetWidth()
-	TorteMe.sv.HUD.height = TorteMeUI:GetHeight()
+  TorteMe.sv.HUD.width = TorteMeUI:GetWidth()
+  TorteMe.sv.HUD.height = TorteMeUI:GetHeight()
 end
 
 function TorteMe:RestoreHUDPosition()
@@ -644,7 +615,7 @@ function TorteMe:RestoreHUDPosition()
   local top = TorteMe.sv.HUD.top
   local height = TorteMe.sv.HUD.height
   local width = TorteMe.sv.HUD.width
- 
+
   TorteMeUI:ClearAnchors()
   TorteMeUI:SetAnchor(TOPLEFT, GuiRoot, TOPLEFT, left, top)
   TorteMeUI:SetWidth(width)

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -12,7 +12,7 @@ Return: isPlayerInCyrodiil bool
 
 function TorteMe:IsPlayerInCyrodiil()
   local isPlayerInCyrodiil = false
-  if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == 181 then
+  if GetParentZoneId(GetZoneId(GetUnitZoneIndex("player"))) == TorteMe.const.ZONEID_CYRODIIL then
     isPlayerInCyrodiil = true
   end
   return isPlayerInCyrodiil

--- a/Helpers.lua
+++ b/Helpers.lua
@@ -420,7 +420,7 @@ function TorteMe:DelveBonusReminderLoop()
 	--*** SHOULD NOT LOOP ***
 
 	--Not in Cyrodiil or tortes are turned off safeguard, cancel events, set loop type to none and return
-	if isPlayerInCyrodiil == false or TorteMe.enableTortes == true and TorteMe.torteEventsInitialized == true then
+	if isPlayerInCyrodiil == false or TorteMe.sv.Torte.enableTortes == true and TorteMe.torteEventsInitialized == true then
 		TorteMe:Log("Catch Exited of Cyrodiil without cancelling events", true, 15)
 		TorteMe:CancelCyrodiilTorteEvents() 
 		return

--- a/TorteMe.lua
+++ b/TorteMe.lua
@@ -22,7 +22,9 @@ TorteMe.torteItems = {
   171329, --Alliance Skill Gain 100% Boost (Molten War Torte)
   171323  --Alliance Skill Gain 50% Boost (Colovian War Torte)
 }
-
+TorteMe.const = {
+  ZONEID_CYRODIIL = 181,
+}
 
 TorteMe.torteLoopType = "none"
 TorteMe.torteEventsInitialized = false
@@ -131,7 +133,7 @@ function TorteMe.OnPlayerLoaded(_, playerZoned)
 
   --This portion handles initalizing or cancelling the reminder loop depending on if your in our of cyrodiil and the status of turning on or off the tracking.
   --You have just logged in (while inside), done a reloadui (while inside) or zoned into cyrodiil from outside of Cyrodiil.
-  if (TorteMe:IsPlayerInCyrodiil() and TorteMe.initialLoad == true) or (TorteMe:IsPlayerInCyrodiil() and initialLoad == false and TorteMe.sv.Zone.oldParentZoneId ~= 181)  then
+  if (TorteMe:IsPlayerInCyrodiil() and TorteMe.initialLoad == true) or (TorteMe:IsPlayerInCyrodiil() and initialLoad == false and TorteMe.sv.Zone.oldParentZoneId ~= TorteMe.const.ZONEID_CYRODIIL)  then
     --You have zoned into cyrdooil, have enable tortes turned on but haqve not initialized your events
     if TorteMe.sv.Torte.enableTortes == true then
       if TorteMe.torteEventsInitialized == false then

--- a/TorteMe.lua
+++ b/TorteMe.lua
@@ -54,7 +54,7 @@ TorteMe.Defaults.HUD.enabled = false
 
 --Debug
 TorteMe.Defaults.Debug = {}
-TorteMe.Defaults.Debug.showDebug = true
+TorteMe.Defaults.Debug.showDebug = false --Should be false by default
 TorteMe.Defaults.Debug.showDebugLevel = 2
 
 --Zone Info

--- a/TorteMe.lua
+++ b/TorteMe.lua
@@ -41,6 +41,9 @@ TorteMe.Defaults.Torte.enableTortes = true
 TorteMe.Defaults.Torte.autoConsume = true
 TorteMe.Defaults.Torte.torteNotifyWhenBelow = 5
 TorteMe.Defaults.Torte.torteNotificationTime = 5
+
+--Delve
+TorteMe.Defaults.Torte.enableDelves = true
 TorteMe.Defaults.Torte.delveNotificationTime = 10
 
 

--- a/TorteMe.lua
+++ b/TorteMe.lua
@@ -12,15 +12,15 @@ TorteMe.delveBonusBuffs = {
 }
 
 TorteMe.torteBuffs = {
-	147734, --Alliance Skill Gain 150% Boost (White-Gold War-Torte)
-	147733, --Alliance Skill Gain 100% Boost (Molten War Torte)
-	147687  --Alliance Skill Gain 50% Boost (Colovian War Torte)
+  147734, --Alliance Skill Gain 150% Boost (White-Gold War-Torte)
+  147733, --Alliance Skill Gain 100% Boost (Molten War Torte)
+  147687  --Alliance Skill Gain 50% Boost (Colovian War Torte)
 }
 
 TorteMe.torteItems = {
-	171432, --Alliance Skill Gain 150% Boost (White-Gold War-Torte)
-	171329, --Alliance Skill Gain 100% Boost (Molten War Torte)
-	171323  --Alliance Skill Gain 50% Boost (Colovian War Torte)
+  171432, --Alliance Skill Gain 150% Boost (White-Gold War-Torte)
+  171329, --Alliance Skill Gain 100% Boost (Molten War Torte)
+  171323  --Alliance Skill Gain 50% Boost (Colovian War Torte)
 }
 
 
@@ -74,78 +74,78 @@ TorteMe.Defaults.Zone.oldZoneName = "Unknown"
 --]]
 
 function TorteMe.OnAddOnLoaded(event, addonName)
-	if addonName == TorteMe.name then
-		TorteMe:Initialize()
-		EVENT_MANAGER:UnregisterForEvent(TorteMe.name, EVENT_ADD_ON_LOADED)
-		TorteMe:RestoreHUDPosition()
-	end
+  if addonName == TorteMe.name then
+    TorteMe:Initialize()
+    EVENT_MANAGER:UnregisterForEvent(TorteMe.name, EVENT_ADD_ON_LOADED)
+    TorteMe:RestoreHUDPosition()
+  end
 end
 
 --[[
 *****************************************************************************************
- 
- Setup Saved Variabless and registers event that will run after every loading screen.
- This will run only on initial loqad or if you perform /reloadUI
+
+  Setup Saved Variabless and registers event that will run after every loading screen.
+  This will run only on initial loqad or if you perform /reloadUI
 
 *****************************************************************************************
 --]]
 
 function TorteMe.Initialize()
-	TorteMe.sv = ZO_SavedVars:NewCharacterIdSettings("TorteMeVariables", 1, nil, TorteMe.Defaults)
-	EVENT_MANAGER:RegisterForEvent(TorteMe.name, EVENT_PLAYER_ACTIVATED, TorteMe.OnPlayerLoaded)
+  TorteMe.sv = ZO_SavedVars:NewCharacterIdSettings("TorteMeVariables", 1, nil, TorteMe.Defaults)
+  EVENT_MANAGER:RegisterForEvent(TorteMe.name, EVENT_PLAYER_ACTIVATED, TorteMe.OnPlayerLoaded)
 end
 
 --[[
 *****************************************************************************************
- 
- Runs after any loading screen regaqrdless of if it was from zoning or from /reloadui.
 
- playerZoned: true = just logged in or zoned
-			  false = a /reloadui was performed.
-			  
- initialLoad: Is set to true when add in is initial loaded set to false here.  Is used
+  Runs after any loading screen regaqrdless of if it was from zoning or from /reloadui.
+
+  playerZoned: true = just logged in or zoned
+        false = a /reloadui was performed.
+
+  initialLoad: Is set to true when add in is initial loaded set to false here.  Is used
               to flag that you need to run CreateSettingsWindow which should only happen
-			  once.
-			  
- Will call captureZoneInfo to capture old/new Zone information and save it to variables.
+        once.
+
+  Will call captureZoneInfo to capture old/new Zone information and save it to variables.
 *****************************************************************************************
 --]]
 
 -- Function Runs anytime a load screen has been activated it simply continues to get Status noting it was activated by an event vs. timer
 function TorteMe.OnPlayerLoaded(_, playerZoned)
-	EVENT_MANAGER:UnregisterForEvent(TorteMe.name, EVENT_PLAYER_ACTIVATED)
-	EVENT_MANAGER:RegisterForEvent(TorteMe.name, EVENT_PLAYER_ACTIVATED, TorteMe.OnPlayerLoaded)
+  EVENT_MANAGER:UnregisterForEvent(TorteMe.name, EVENT_PLAYER_ACTIVATED)
+  EVENT_MANAGER:RegisterForEvent(TorteMe.name, EVENT_PLAYER_ACTIVATED, TorteMe.OnPlayerLoaded)
 
-	if TorteMe.initialLoad then
-		TorteMe:Log("|r" .. TorteMe.displayName .. " by |cff0000@evainefaye |rloaded.")
-		TorteMe:CreateSettingsWindow()
-		if playerZoned then
-			TorteMe:CaptureZoneInfo("login")
-		else
-			TorteMe:CaptureZoneInfo("reload")
-		end
-	else
-		TorteMe:CaptureZoneInfo("zone")
-	end
+  if TorteMe.initialLoad then
+    TorteMe:Log("|r" .. TorteMe.displayName .. " by |cff0000@evainefaye |rloaded.")
+    TorteMe:CreateSettingsWindow()
+    if playerZoned then
+      TorteMe:CaptureZoneInfo("login")
+    else
+      TorteMe:CaptureZoneInfo("reload")
+    end
+  else
+    TorteMe:CaptureZoneInfo("zone")
+  end
 
 
-	--This portion handles initalizing or cancelling the reminder loop depending on if your in our of cyrodiil and the status of turning on or off the tracking.
-	--You have just logged in (while inside), done a reloadui (while inside) or zoned into cyrodiil from outside of Cyrodiil.
-	if (TorteMe:IsPlayerInCyrodiil() and TorteMe.initialLoad == true) or (TorteMe:IsPlayerInCyrodiil() and initialLoad == false and TorteMe.sv.Zone.oldParentZoneId ~= 181)  then
-		--You have zoned into cyrdooil, have enable tortes turned on but haqve not initialized your events
-		if TorteMe.sv.Torte.enableTortes == true then
-			if TorteMe.torteEventsInitialized == false then
-				TorteMe:InitializeCyrodiilTorteEvents()
-			end
-		else
-			--you do not have enable tortes turned on, so turn off events if they got turned on somehow.
-			if TorteMe.torteEventsInitalized == true then
-				TorteMe:CancelCyrodiilTorteEvents()
-			end
-		end
-	end
-	TorteMe.initialLoad = false
-	TorteMe:TorteSetup()
+  --This portion handles initalizing or cancelling the reminder loop depending on if your in our of cyrodiil and the status of turning on or off the tracking.
+  --You have just logged in (while inside), done a reloadui (while inside) or zoned into cyrodiil from outside of Cyrodiil.
+  if (TorteMe:IsPlayerInCyrodiil() and TorteMe.initialLoad == true) or (TorteMe:IsPlayerInCyrodiil() and initialLoad == false and TorteMe.sv.Zone.oldParentZoneId ~= 181)  then
+    --You have zoned into cyrdooil, have enable tortes turned on but haqve not initialized your events
+    if TorteMe.sv.Torte.enableTortes == true then
+      if TorteMe.torteEventsInitialized == false then
+        TorteMe:InitializeCyrodiilTorteEvents()
+      end
+    else
+      --you do not have enable tortes turned on, so turn off events if they got turned on somehow.
+      if TorteMe.torteEventsInitalized == true then
+        TorteMe:CancelCyrodiilTorteEvents()
+      end
+    end
+  end
+  TorteMe.initialLoad = false
+  TorteMe:TorteSetup()
 end
 
 EVENT_MANAGER:RegisterForEvent(TorteMe.name, EVENT_ADD_ON_LOADED, TorteMe.OnAddOnLoaded)

--- a/TorteMe.lua
+++ b/TorteMe.lua
@@ -100,7 +100,7 @@ end
 --[[
 *****************************************************************************************
 
-  Runs after any loading screen regaqrdless of if it was from zoning or from /reloadui.
+  Runs after any loading screen regardless of if it was from zoning or from /reloadui.
 
   playerZoned: true = just logged in or zoned
         false = a /reloadui was performed.

--- a/TorteMe.xml
+++ b/TorteMe.xml
@@ -1,30 +1,30 @@
 <GuiXml>
-	<Controls>
-		<TopLevelControl name="TorteMeUI" mouseEnabled="true" movable="true" clampedToScreen="true" resizeHandleSize="0">
-			<Dimensions x="180" y="45" />
-			<Anchor point="TOPLEFT" relativeTo="GuiRoot" relativePoint="TOPLEFT" offsetX="24" offsetY="190" />
-			<OnMoveStop>
-				TorteMe.OnIndicatorMoveStop()
-			</OnMoveStop>
-			<OnResizeStop>
-				TorteMe.OnResizeStop()
-			</OnResizeStop>
-			<Controls>
-			<Backdrop name="$(parent)Bg" inherits="ZO_DefaultBackdrop" />
-				<Label name="$(parent)TorteBuff" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="LEFT" text="War-Torte:">
-					<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" />
-				</Label>
-				<Label name="$(parent)TorteBuffTime" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="RIGHT">
-					<Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" />
-				</Label>
-				<Label name="$(parent)DelveBonus" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="LEFT" text="Delve Bonus:">
-					<Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" />
-				</Label>
-				<Label name="$(parent)DelveBonusTime" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="RIGHT">
-					<Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" />
-				</Label>
+  <Controls>
+    <TopLevelControl name="TorteMeUI" mouseEnabled="true" movable="true" clampedToScreen="true" resizeHandleSize="0">
+      <Dimensions x="180" y="45" />
+      <Anchor point="TOPLEFT" relativeTo="GuiRoot" relativePoint="TOPLEFT" offsetX="24" offsetY="190" />
+      <OnMoveStop>
+        TorteMe.OnIndicatorMoveStop()
+      </OnMoveStop>
+      <OnResizeStop>
+        TorteMe.OnResizeStop()
+      </OnResizeStop>
+      <Controls>
+      <Backdrop name="$(parent)Bg" inherits="ZO_DefaultBackdrop" />
+        <Label name="$(parent)TorteBuff" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="LEFT" text="War-Torte:">
+          <Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" />
+        </Label>
+        <Label name="$(parent)TorteBuffTime" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="RIGHT">
+          <Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" />
+        </Label>
+        <Label name="$(parent)DelveBonus" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="LEFT" text="Delve Bonus:">
+          <Anchor point="BOTTOMLEFT" relativeTo="$(parent)" relativePoint="BOTTOMLEFT" />
+        </Label>
+        <Label name="$(parent)DelveBonusTime" width="100" height="25" font="ZoFontChat" inheritAlpha="true" color="3A92FF" wrapMode="TRUNCATE" verticalAlignment="TOP" horizontalAligment="RIGHT">
+          <Anchor point="BOTTOMRIGHT" relativeTo="$(parent)" relativePoint="BOTTOMRIGHT" />
+        </Label>
 
-			</Controls>
-		</TopLevelControl>
-	</Controls>
+      </Controls>
+    </TopLevelControl>
+  </Controls>
 </GuiXml>

--- a/TorteSetup.lua
+++ b/TorteSetup.lua
@@ -28,20 +28,25 @@ function TorteMe:TorteSetup()
 		TorteMeUI:SetHidden(true)
 	end
 
-	local delveBonusInfo = TorteMe:DoesPlayerHaveDelveBonus()
-	if delveBonusInfo.delveBonusActive == true then
-		TorteMe:UpdateDelveHUD(delveBonusInfo.delveBonusName, delveBonusInfo.delveBonusEnding)
-	else
-		TorteMeUIDelveBonusTime:SetText("EXPIRED")
-		TorteMeUIDelveBonusTime:SetColor(255,0,0,255)
-	end
-	local torteBuffInfo = TorteMe:DoesPlayerHaveTorteBuff()
-	if torteBuffInfo.torteBuffActive == true then
-		TorteMe:UpdateTorteHUD(torteBuffInfo.torteBuffName, torteBuffInfo.torteBuffEnding)
-	else 
-		TorteMeUITorteBuffTime:SetText("EXPIRED")
-		TorteMeUITorteBuffTime:SetColor(255,0,0,255)
-	end
-	TorteMe:TorteBuffReminderLoop()
-	TorteMe:DelveBonusReminderLoop()	
+  if TorteMe.sv.Torte.enableDelves == true then
+    local delveBonusInfo = TorteMe:DoesPlayerHaveDelveBonus()
+    if delveBonusInfo.delveBonusActive == true then
+      TorteMe:UpdateDelveHUD(delveBonusInfo.delveBonusName, delveBonusInfo.delveBonusEnding)
+    else
+      TorteMeUIDelveBonusTime:SetText("EXPIRED")
+      TorteMeUIDelveBonusTime:SetColor(255,0,0,255)
+    end
+    TorteMe:DelveBonusReminderLoop()
+  end
+
+  if TorteMe.sv.Torte.enableTortes == true then
+    local torteBuffInfo = TorteMe:DoesPlayerHaveTorteBuff()
+    if torteBuffInfo.torteBuffActive == true then
+      TorteMe:UpdateTorteHUD(torteBuffInfo.torteBuffName, torteBuffInfo.torteBuffEnding)
+    else
+      TorteMeUITorteBuffTime:SetText("EXPIRED")
+      TorteMeUITorteBuffTime:SetColor(255,0,0,255)
+    end
+    TorteMe:TorteBuffReminderLoop()
+  end
 end

--- a/TorteSetup.lua
+++ b/TorteSetup.lua
@@ -1,32 +1,32 @@
 TorteMe = TorteMe or {}
 
 --[[
-	Tun Upon Zone Into or out of Cyroddiil, when auto consume is turned on or off, or when you turn on or off tacking of tortes.
-	Does NOT run if you zone WITHIN cyrodiil.
+  Tun Upon Zone Into or out of Cyroddiil, when auto consume is turned on or off, or when you turn on or off tacking of tortes.
+  Does NOT run if you zone WITHIN cyrodiil.
 --]]
 
 function TorteMe:TorteSetup()
 
-	TorteMe:Log("Player Login, Zone, or reload detected.", true, 25)
-	local isPlayerInCyrodiil = TorteMe:IsPlayerInCyrodiil() 
-	TorteMe:Log("Is Player in Cyrodiil: " .. tostring(isPlayerInCyrodiil), true, 50)	
+  TorteMe:Log("Player Login, Zone, or reload detected.", true, 25)
+  local isPlayerInCyrodiil = TorteMe:IsPlayerInCyrodiil()
+  TorteMe:Log("Is Player in Cyrodiil: " .. tostring(isPlayerInCyrodiil), true, 50)
 
-	--Player is IN cyrodiil but torte tracking is turned off OR player is not in cyrodiil, then disable events and do nothing further
-	if (TorteMe.sv.Torte.enableTortes == false and isPlayerInCyrodiil == true) or (isPlayerInCyrodiil == false and TorteMe.torteEventsInitialized == true) then
-		TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 50)
-		TorteMeUI:SetHidden(true)
-		TorteMe:CancelCyrodiilTorteEvents()
-		return
-	end
-	if (TorteMe.sv.Torte.enableTortes == true and isPlayerInCyrodiil ) and TorteMe.torteEventsInitialized == false then
-		TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 50)
-		TorteMe:InitializeCyrodiilTorteEvents()
-	end 
-	if (isPlayerInCyrodiil) then 
-		TorteMeUI:SetHidden(not TorteMe.sv.HUD.enabled)
-	else 
-		TorteMeUI:SetHidden(true)
-	end
+  --Player is IN cyrodiil but torte tracking is turned off OR player is not in cyrodiil, then disable events and do nothing further
+  if (TorteMe.sv.Torte.enableTortes == false and isPlayerInCyrodiil == true) or (isPlayerInCyrodiil == false and TorteMe.torteEventsInitialized == true) then
+    TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 50)
+    TorteMeUI:SetHidden(true)
+    TorteMe:CancelCyrodiilTorteEvents()
+    return
+  end
+  if (TorteMe.sv.Torte.enableTortes == true and isPlayerInCyrodiil ) and TorteMe.torteEventsInitialized == false then
+    TorteMe:Log("Tortes Enabled: " .. tostring(TorteMe.sv.Torte.enableTortes), true, 50)
+    TorteMe:InitializeCyrodiilTorteEvents()
+  end
+  if (isPlayerInCyrodiil) then
+    TorteMeUI:SetHidden(not TorteMe.sv.HUD.enabled)
+  else
+    TorteMeUI:SetHidden(true)
+  end
 
   if TorteMe.sv.Torte.enableDelves == true then
     local delveBonusInfo = TorteMe:DoesPlayerHaveDelveBonus()


### PR DESCRIPTION
- Refactored CaptureZoneInfo to make it easier to read and reduce the amount of duplicate code.
- Made ZONEID_CYRODIIL so 181 isn't hardcoded every where
- Changed mixed tab/spaces to two space indentation
- Ordered settings window, to make it little more easier to read, and prepare for potential future adjustments